### PR TITLE
FOGL-2517 python3-rpi.gpio apt package added in control file

### DIFF
--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -3,7 +3,7 @@ Version: 0.0
 Section: devel
 Priority: optional
 Architecture: armhf
-Depends: foglamp
+Depends: foglamp,python3-rpi.gpio
 Conflicts:
 Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
 Homepage: http://www.dianomic.com


### PR DESCRIPTION
```
pi@raspberrypi:~/foglamp-south-pt100 $ sudo cp /home/pi/foglamp-south-pt100/packages/build/foglamp-south-pt100-1.5.0-armhf.deb /var/cache/apt/archives/.
pi@raspberrypi:~/foglamp-south-pt100 $ sudo apt install /var/cache/apt/archives/foglamp-south-pt100-1.5.0-armhf.deb 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
Note, selecting 'foglamp-south-pt100' instead of '/var/cache/apt/archives/foglamp-south-pt100-1.5.0-armhf.deb'
The following packages were automatically installed and are no longer required:
  libmodbus-dev libmodbus5 libsensors4 sysstat
Use 'sudo apt autoremove' to remove them.
The following additional packages will be installed:
  python3-rpi.gpio
The following NEW packages will be installed:
  foglamp-south-pt100 python3-rpi.gpio
0 upgraded, 2 newly installed, 0 to remove and 31 not upgraded.
Need to get 23.6 kB/28.6 kB of archives.
After this operation, 75.8 kB of additional disk space will be used.
Do you want to continue? [Y/n] Y
Get:1 http://archive.raspberrypi.org/debian stretch/main armhf python3-rpi.gpio armhf 0.6.5~stretch-1 [23.6 kB]
Fetched 23.6 kB in 1s (21.2 kB/s)          
Selecting previously unselected package python3-rpi.gpio.
(Reading database ... 56748 files and directories currently installed.)
Preparing to unpack .../python3-rpi.gpio_0.6.5~stretch-1_armhf.deb ...
Unpacking python3-rpi.gpio (0.6.5~stretch-1) ...
Selecting previously unselected package foglamp-south-pt100.
Preparing to unpack .../foglamp-south-pt100-1.5.0-armhf.deb ...
Unpacking foglamp-south-pt100 (1.5.0) ...
Setting up python3-rpi.gpio (0.6.5~stretch-1) ...
Setting up foglamp-south-pt100 (1.5.0) ...
PT100 plugin is now installed.

```